### PR TITLE
Teacher student access

### DIFF
--- a/backend/mastery/access_policies/goal.py
+++ b/backend/mastery/access_policies/goal.py
@@ -41,7 +41,7 @@ class GoalAccessPolicy(BaseAccessPolicy):
             "effect": "allow",
             "condition": "can_student_modify_goal"
         },
-        # Teachers can modify goals in their scope
+        # Teachers can modify goals they have created and according to students and groups they teach
         {
             "action": ["update", "partial_update", "destroy"],
             "principal": ["role:teacher"],
@@ -97,8 +97,8 @@ class GoalAccessPolicy(BaseAccessPolicy):
                 filters |= Q(group__members__groups__id__in=teacher_basis_group_ids)
 
             # Students: Own personal goals + group goals in their groups
+            filters |= Q(student=requester)
             if student_group_ids:
-                filters |= Q(student=requester)
                 filters |= Q(group_id__in=student_group_ids)
 
             return qs.filter(filters).distinct()
@@ -183,7 +183,7 @@ class GoalAccessPolicy(BaseAccessPolicy):
             target_goal = view.get_object()
             requester = request.user
 
-            if target_goal.created_by_id is not None and target_goal.created_by_id != requester.id:
+            if target_goal.created_by_id != requester.id:
                 # Teachers can only modify goals they created
                 return False
 

--- a/backend/mastery/serializers.py
+++ b/backend/mastery/serializers.py
@@ -98,16 +98,6 @@ class ObservationSerializer(BaseModelSerializer):
     class Meta:
         model = models.Observation
         fields = '__all__'
-    def get_fields(self):
-        # Get the base fields (with FK transformations)
-        fields = super().get_fields()
-        
-        # Apply access policy field scoping
-        request = self.context.get('request')
-        if request:
-            fields = ObservationAccessPolicy.scope_fields(request, fields, self.instance)
-        
-        return fields
 
 
 class StatusSerializer(BaseModelSerializer):

--- a/backend/mastery/tests/api_tests/test_permissions_observation.py
+++ b/backend/mastery/tests/api_tests/test_permissions_observation.py
@@ -151,17 +151,20 @@ def test_teaching_group_teacher_observation_access(
         "student_id": student.id,
         "goal_id": observation_on_group_goal.goal.id,
         "is_visible_to_student": True,
+        "created_by_id": teacher.id
     }, format='json')
     assert resp.status_code == 201
     created_group_obs_id = resp.json()["id"]
 
     # Teacher can update observations on group goals they teach
-    resp = client.put(f"/api/observations/{observation_on_group_goal.id}/", {
-        "student_id": observation_on_group_goal.student.id,
+    resp = client.put(f"/api/observations/{created_group_obs_id}/", {
+        "student_id": student.id,
         "goal_id": observation_on_group_goal.goal.id,
         "is_visible_to_student": False,
+        "feedforward": "Keep up the good work!",
     }, format='json')
     assert resp.status_code == 200
+    assert resp.json()['feedforward'] == "Keep up the good work!"
 
     # Teacher can delete observations on group goals tehy teach
     resp = client.delete(f"/api/observations/{created_group_obs_id}/")
@@ -196,6 +199,7 @@ def test_teaching_group_teacher_observation_access(
         "student_id": student.id,
         "goal_id": goal_other_group.id,
         "is_visible_to_student": False,
+        "feedforward": "Great effort!",
     }, format='json')
     assert resp.status_code == 403
 
@@ -208,6 +212,7 @@ def test_teaching_group_teacher_observation_access(
         "student_id": student.id,
         "goal_id": personal_goal_in_taught_subject.id,
         "is_visible_to_student": True,
+        "created_by_id": teacher.id
     }, format='json')
     assert resp.status_code == 201
     created_taught_subject_obs_id = resp.json()["id"]
@@ -225,14 +230,17 @@ def test_teaching_group_teacher_observation_access(
         "student_id": student.id,
         "goal_id": personal_goal_in_taught_subject.id,
         "is_visible_to_student": False,
+        "feedforward": "Great effort on reading!",
     }, format='json')
     assert resp.status_code == 200
+    assert resp.json()['feedforward'] == "Great effort on reading!"
 
     # Teacher cannot update observations on personal goals in subjects they don't teach
     resp = client.put(f"/api/observations/{observation_untaught_subject.id}/", {
         "student_id": student.id,
         "goal_id": personal_goal_untaught_subject.id,
         "is_visible_to_student": False,
+        "feedforward": "You can do it!",
     }, format='json')
     assert resp.status_code == 403
 
@@ -300,6 +308,7 @@ def test_basis_group_teacher_observation_access(
         "student_id": student.id,
         "goal_id": observation_on_personal_goal.goal.id,
         "is_visible_to_student": True,
+        "created_by_id": teacher.id
     }, format='json')
     assert resp.status_code == 201
     created_personal_obs_id = resp.json()["id"]
@@ -308,8 +317,10 @@ def test_basis_group_teacher_observation_access(
         "student_id": student.id,
         "goal_id": observation_on_personal_goal.goal.id,
         "is_visible_to_student": False,
+        "feedforward": "You can do it!",
     }, format='json')
     assert resp.status_code == 200
+    assert resp.json()['feedforward'] == "You can do it!"
 
     resp = client.delete(f"/api/observations/{created_personal_obs_id}/")
     assert resp.status_code == 204
@@ -331,6 +342,7 @@ def test_basis_group_teacher_observation_access(
         "student_id": student.id,
         "goal_id": observation_on_personal_goal.goal.id,
         "is_visible_to_student": False,
+        "feedforward": "Do your best!",
     }, format='json')
     assert resp.status_code == 403
 


### PR DESCRIPTION
  ### Student and teacher access on goals and observations

 ### How it works now

  **What teachers can see:**
  - ✅ Teaching group teachers can see group goals in the subjects
  they teach
  - ✅ Basis group teachers can see everything for their students -
  personal goals and group goals across all subjects

  **What teachers can modify:**
  - ✅ Group goals: You need to teach that specific group to edit them
  - ✅ Personal goals: You need to be the student's basis group
  teacher

  So if you're a basis teacher, you can check on how your student is
  doing in all their subjects, but you can only edit their personal
  goals. If you want to edit a group goal, you need to actually teach
  that teaching group.

  ### What changed in the code

  - ✅ Separated teaching and basis group teacher access for both
  goals and observations
  - ✅ Added CRUD permissions for teachers and students
